### PR TITLE
Core: Correct transaction constant used.

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -655,7 +655,7 @@
 
         public static function isTransactionActive()
         {
-            return (bool) self::$_transaction_active == Transaction::STATE_STARTED;
+            return (bool) self::$_transaction_active == Transaction::DB_TRANSACTION_STARTED;
         }
 
         /**


### PR DESCRIPTION
Transaction constant names seems to have evolved over time and in Core old
constant name of Transaction::STATE_STARTED seems has been forgotten to be
changed to Transaction::DB_TRANSACTION_STARTED.

This change fixes the installation problem with thebuggenie master:

PHP Fatal error:  Undefined class constant 'STATE_STARTED' in .../thebuggenie/vendor/thebuggenie/b2db/src/Core.php on line 658, referer: ...