### PR TITLE
Introduce PDO-based types rather than always using string

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -286,6 +286,7 @@
             $time = Core::getDebugTime() - $pretime;
             $sql = $statement->printSQL();
             $values = ($statement->getCriteria() instanceof Criteria) ? $statement->getCriteria()->getValues() : array();
+            $values = array_map(function($v) { return $v['value']; }, $values);
 
             $trace = self::getRelevantDebugBacktraceElement();
 

--- a/src/Resultset.php
+++ b/src/Resultset.php
@@ -135,6 +135,7 @@
             if ($this->crit instanceof Criteria) {
                 $str .= $this->crit->getSQL();
                 foreach ($this->crit->getValues() as $val) {
+                    $val = $val['values'];
                     if (!is_int($val)) {
                         $val = '\'' . $val . '\'';
                     }

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -93,7 +93,25 @@
                     $pretime = Core::getDebugTime();
                 }
 
-                $res = $this->statement->execute($values);
+                for ($i = 0; $i < sizeof($values); $i++) {
+                    $value = $values[$i]['value'];
+                    $type = $values[$i]['type'];
+                    switch ($type) {
+                    case 'boolean':
+                        $pdotype = \PDO::PARAM_BOOL;
+                        break;
+                    case 'integer':
+                        $pdotype = \PDO::PARAM_INT;
+                        break;
+                    case 'blob':
+                        $pdotype = \PDO::PARAM_LOB;
+                        break;
+                    default:
+                        $pdotype = \PDO::PARAM_STR;
+                    }
+                    $this->statement->bindValue($i+1, $value, $pdotype);
+                }
+                $res = $this->statement->execute();
 
                 if (!$res) {
                     $error = $this->statement->errorInfo();
@@ -203,6 +221,7 @@
             if ($this->getCriteria() instanceof Criteria) {
                 $str .= $this->crit->getSQL();
                 foreach ($this->crit->getValues() as $val) {
+                    $val = $val['value'];
                     if (is_null($val)) {
                         $val = 'null';
                     } elseif (!is_int($val)) {

--- a/src/Table.php
+++ b/src/Table.php
@@ -655,7 +655,7 @@
                     $changed = true;
                     $crit->addUpdate($column['name'], $value);
                 } elseif ($column['name'] != $this->getIdColumn()) {
-                    $crit->addInsert($column['name'], $value);
+                    $crit->addInsert($column['name'], $value, $column['type']);
                 }
             }
             if ($id) {


### PR DESCRIPTION
This commit introduces the capability to use PDO data types when updating and inserting data.

PDO has support for applying the required database specific encoding for the various databases and data types that it supports providing the type of data is specified during the preparation of the statement. A `$type` parameter is added to the `addUpdate()`, `addInsert()` and `addValue()` functions to allow the type of data to be specified. It is expected that this `$type` will be specified using the same type descriptors as b2db uses for column types. Later during the execution of the query these types are mapped to the corresponding PDO data types, to which the value is bound. This reduces the amount of database specific code, for example `_addValue()` becomes database agnostic under this model.

If no `$type` is specified then a default of `PDO::PARAM_STR` is used, which is consistent with the existing code where the values are provided to `execute()` as an array:

> An array of values with as many elements as there are bound parameters in the SQL statement being executed. All values are treated as PDO::PARAM_STR.
> http://php.net/manual/en/pdostatement.execute.php

This commit improves the reliability of storing uploaded files in a postgresql database by using the `PDO::PARAM_LOB` type which performs the necessary escaping and unescaping of binary data.
http://www.it-iss.com/postgresql/postgresql-pdo-reading-and-writing-binary-content-to-the-database/

This is an intrusive commit since it modifies the b2db public `addInsert()` function in an incompatible way by adding the `$type` parameter prior to the already existing `$operator` and `$variable` parameters. This results in the simplest commit since those parameters do not appear to be used anywhere within b2db or TBG. However, those parameters may be used in other projects outside my awareness. It is a small change to move the `$type` parameter to the end of the parameter list to maintain backwards compatibility with existing code, if that is preferred. Alternatively, it may be desirable to remove the `$operator` and `$variable` parameters from the `addInsert()` function since it is not immediately clear what purpose they serve.

I believe this commit is merge-ready, depending on the acceptance of the above points. However I am more than happy to rework it based on any feedback.
